### PR TITLE
general: remove home-manager

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1686545384,
-        "narHash": "sha256-XniReOaWLjubBAXk6Wx2Ny6/b9Xdsx3viLhhs7ycuWw=",
+        "lastModified": 1686916043,
+        "narHash": "sha256-/igu6soWAJUMtHdwxC4NjFDgPjdkDYRP1p6MthSqARk=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "55eea2030a42845102334eb29f054f0c6604a32c",
+        "rev": "e0179917d8172f2d5a4372bbab6db76e5b0a3ce5",
         "type": "github"
       },
       "original": {
@@ -307,26 +307,6 @@
         "type": "github"
       }
     },
-    "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1686564129,
-        "narHash": "sha256-jzb2mHvQEZJL3a3ANhTeLIaa1nyjFJ/RzUJjCJme/V4=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "9e37a1b6f9507ed27080518ff4007988a50c957e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
     "mission-control": {
       "locked": {
         "lastModified": 1683658484,
@@ -396,11 +376,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1686431482,
-        "narHash": "sha256-oPVQ/0YP7yC2ztNsxvWLrV+f0NQ2QAwxbrZ+bgGydEM=",
+        "lastModified": 1686736559,
+        "narHash": "sha256-YyUSVoOKIDAscTx7IZhF9x3qgZ9dPNF19fKk+4c5irc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d3bb401dcfc5a46ce51cdfb5762e70cc75d082d2",
+        "rev": "ddf4688dc7aeb14e8a3c549cb6aa6337f187a884",
         "type": "github"
       },
       "original": {
@@ -443,11 +423,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1686501370,
-        "narHash": "sha256-G0WuM9fqTPRc2URKP9Lgi5nhZMqsfHGrdEbrLvAPJcg=",
+        "lastModified": 1686776226,
+        "narHash": "sha256-o6WbKvENj98QJz9Mco6T6SZGrjPewMDAFyKg0Lp8avU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "75a5ebf473cd60148ba9aec0d219f72e5cf52519",
+        "rev": "0d2cf7fe5fa05d5271a15a8933414ee0a1570648",
         "type": "github"
       },
       "original": {
@@ -464,7 +444,6 @@
         "ethereum-nix": "ethereum-nix",
         "flake-parts": "flake-parts_4",
         "flake-root": "flake-root_2",
-        "home-manager": "home-manager",
         "mission-control": "mission-control",
         "nixpkgs": "nixpkgs_3",
         "nixpkgs-stable": "nixpkgs-stable"

--- a/flake.nix
+++ b/flake.nix
@@ -296,6 +296,35 @@
                   };
                 })
 
+                #################################################################### MOTD (no options)
+                (mkIf true {
+                  programs.rust-motd = {
+                    enable = true;
+                    enableMotdInSSHD = true;
+                    settings = {
+                      banner = {
+                        color = "yellow";
+                        command = ''
+                          echo ""
+                          echo " +-------------+"
+                          echo " | 10110 010   |"
+                          echo " | 101 101 10  |"
+                          echo " | 0   _____   |"
+                          echo " |    / ___ \  |"
+                          echo " |   / /__/ /  |"
+                          echo " +--/ _____/---+"
+                          echo "   / /"
+                          echo "  /_/"
+                          echo ""
+                          systemctl --failed --quiet
+                        '';
+                      };
+                      uptime.prefix = "Uptime:";
+                      last_login.core = 2;
+                    };
+                  };
+                })
+
                 #################################################################### WIREGUARD (no options)
                 (mkIf true {
                   systemd.services.wg0 = {

--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,6 @@
     ethereum-nix.url = "github:nix-community/ethereum.nix";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-root.url = "github:srid/flake-root";
-    home-manager.inputs.nixpkgs.follows = "nixpkgs";
-    home-manager.url = "github:nix-community/home-manager";
     mission-control.url = "github:Platonic-Systems/mission-control";
     nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-23.05";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
@@ -35,7 +33,6 @@
     , disko
     , ethereum-nix
     , flake-parts
-    , home-manager
     , nixpkgs
     , nixpkgs-stable
     , ...
@@ -197,7 +194,6 @@
               ./system/ramdisk.nix
               ./system/formats/netboot-kexec.nix
               self.nixosModules.homestakeros
-              home-manager.nixosModules.home-manager
               disko.nixosModules.disko
               {
                 system.stateVersion = "23.05";
@@ -290,29 +286,13 @@
                   };
                   users.groups.core = { };
                   environment.shells = [ pkgs.fish ];
-                  programs.fish.enable = true;
 
-                  home-manager.users.root.home.stateVersion = config.home-manager.users.core.home.stateVersion;
-                  home-manager.users.core = { pkgs, ... }: {
-
-                    home.packages = with pkgs; [
-                      file
-                      tree
-                      bind # nslookup
-                    ];
-
-                    programs = {
-                      tmux.enable = true;
-                      htop.enable = true;
-                      vim.enable = true;
-                      git.enable = true;
-                      fish.enable = true;
-                      fish.loginShellInit = "fish_add_path --move --prepend --path $HOME/.nix-profile/bin /run/wrappers/bin /etc/profiles/per-user/$USER/bin /run/current-system/sw/bin /nix/var/nix/profiles/default/bin";
-
-                      home-manager.enable = true;
-                    };
-
-                    home.stateVersion = "23.05";
+                  programs = {
+                    tmux.enable = true;
+                    htop.enable = true;
+                    git.enable = true;
+                    fish.enable = true;
+                    fish.loginShellInit = "fish_add_path --move --prepend --path $HOME/.nix-profile/bin /run/wrappers/bin /etc/profiles/per-user/$USER/bin /run/current-system/sw/bin /nix/var/nix/profiles/default/bin";
                   };
                 })
 

--- a/system/default.nix
+++ b/system/default.nix
@@ -55,32 +55,6 @@
     vim
   ];
 
-  programs.rust-motd = {
-    enable = true;
-    enableMotdInSSHD = true;
-    settings = {
-      banner = {
-        color = "yellow";
-        command = ''
-          echo ""
-          echo " +-------------+"
-          echo " | 10110 010   |"
-          echo " | 101 101 10  |"
-          echo " | 0   _____   |"
-          echo " |    / ___ \  |"
-          echo " |   / /__/ /  |"
-          echo " +--/ _____/---+"
-          echo "   / /"
-          echo "  /_/"
-          echo ""
-          systemctl --failed --quiet
-        '';
-      };
-      uptime.prefix = "Uptime:";
-      last_login.core = 2;
-    };
-  };
-
   # Better clock sync via chrony
   services.timesyncd.enable = false;
   services.chrony = {

--- a/system/default.nix
+++ b/system/default.nix
@@ -49,6 +49,10 @@
     btrfs-progs
     kexec-tools
     fuse-overlayfs
+    bind
+    file
+    tree
+    vim
   ];
 
   programs.rust-motd = {
@@ -73,12 +77,7 @@
         '';
       };
       uptime.prefix = "Uptime:";
-      last_login = builtins.listToAttrs (map
-        (user: {
-          name = user;
-          value = 2;
-        })
-        (builtins.attrNames config.home-manager.users));
+      last_login.core = 2;
     };
   };
 


### PR DESCRIPTION
We'll be removing the home-manager module because it has an extensive number of dependencies that are unnecessary for a headless configuration.