### PR TITLE
buidl-script: add flake URL flag

### DIFF
--- a/scripts/buidl.sh
+++ b/scripts/buidl.sh
@@ -31,7 +31,7 @@ Options:
       Set the base configuration with the specified hostname. Available configurations: 'homestakeros'.
 
   -f, --flake <url>
-      Set the URL of the nixobolus flake. The default value is 'github:ponkila/nixobolus'.
+      Set the URL of the nixobolus flake. Default: 'github:ponkila/nixobolus'.
 
   -o, --output <output_path>
       Set the output path for the build result symlinks. Default: './result'.


### PR DESCRIPTION
There was an issue when running the script remotely from the root of another repository that also contains a flake. It would build the local flake instead of the intended remote Nixobolus flake. Removing the local flake check fixes this issue. The ability to change the URL is mainly for development purposes and will default to the main branch of 'ponkila/nixobolus' if not set.