### PR TITLE
system, formats: squashfs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -183,6 +183,9 @@
         nixosModules.kexecTree = {
           imports = [./system ./system/formats/netboot-kexec.nix];
         };
+        nixosModules.squashfs = {
+          imports = [./system ./system/formats/netboot-squashfs.nix];
+        };
       };
     };
 }

--- a/system/formats/netboot-squashfs.nix
+++ b/system/formats/netboot-squashfs.nix
@@ -1,0 +1,75 @@
+{
+  config,
+  lib,
+  pkgs,
+  modulesPath,
+  ...
+}: {
+  # These kmodules are implicit requirements of netboot
+  boot.initrd.availableKernelModules = ["squashfs" "overlay" "btrfs"];
+  boot.initrd.kernelModules = ["loop" "overlay"];
+
+  fileSystems."/" = lib.mkImageMediaOverride {
+    fsType = "tmpfs";
+    options = ["mode=0755"];
+  };
+
+  # In stage 1, mount a tmpfs on top of /nix/store (the squashfs
+  # image) to make this a live CD.
+  fileSystems."/nix/.ro-store" = lib.mkImageMediaOverride {
+    fsType = "squashfs";
+    device = "../nix-store.squashfs";
+    options = ["loop"];
+    neededForBoot = true;
+  };
+
+  fileSystems."/nix/.rw-store" = lib.mkImageMediaOverride {
+    fsType = "tmpfs";
+    options = ["mode=0755"];
+    neededForBoot = true;
+  };
+
+  fileSystems."/nix/store" = lib.mkImageMediaOverride {
+    fsType = "overlay";
+    device = "overlay";
+    options = [
+      "lowerdir=/nix/.ro-store"
+      "upperdir=/nix/.rw-store/store"
+      "workdir=/nix/.rw-store/work"
+    ];
+
+    depends = [
+      "/nix/.ro-store"
+      "/nix/.rw-store/store"
+      "/nix/.rw-store/work"
+    ];
+  };
+
+  boot.postBootCommands = ''
+    # After booting, register the contents of the Nix store in the Nix database in the tmpfs.
+    ${config.nix.package}/bin/nix-store --load-db < /nix/store/nix-path-registration
+    # nixos-rebuild also requires a "system" profile and an /etc/NIXOS tag.
+    touch /etc/NIXOS
+    ${config.nix.package}/bin/nix-env -p /nix/var/nix/profiles/system --set /run/current-system
+  '';
+
+  # Create the squashfs image that contains the Nix store.
+  system.build.squashfsStore = pkgs.callPackage "${toString modulesPath}/../lib/make-squashfs.nix" {
+    # Closures to be copied to the Nix store, namely the init
+    # script and the top-level system configuration directory.
+    storeContents = [config.system.build.toplevel];
+    comp = "zstd -Xcompression-level 2";
+  };
+
+  # A tree containing initrd.zst, bzImage and a squashfs.
+  system.build.squashfs = pkgs.linkFarm "squashfs" [
+    {
+      name = "bzImage";
+      path = "${config.system.build.kernel}/${config.system.boot.loader.kernelFile}";
+    }
+    {
+      name = "squashfs.img";
+      path = "${config.system.build.squashfsStore}";
+    }
+  ];
+}


### PR DESCRIPTION
Adding alternative output format where nix store is separated from initrd. The client has to be able to download the squashfs in stage-1; for this, network drivers should be enabled at stage-1. Also, this format relies on this [patched nixpkgs](https://github.com/majbacka-labs/nixpkgs/tree/patch-init1sh).

Ultimate purpose of this is preventing the following issue: https://github.com/NixOS/nixpkgs/issues/203593. 

