### PR TITLE
netboot-kexec: no bootloader

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -108,7 +108,6 @@
               self.nixosModules.kexecTree
               self.nixosModules.homestakeros
               {
-                boot.loader.grub.enable = false;
                 system.stateVersion = "23.11";
               }
             ]

--- a/modules/netboot-kexec.nix
+++ b/modules/netboot-kexec.nix
@@ -5,6 +5,9 @@
   modulesPath,
   ...
 }: {
+  # No bootloader
+  boot.loader.grub.enable = false;
+
   # These kmodules are implicit requirements of netboot
   boot.initrd.availableKernelModules = ["squashfs" "overlay" "btrfs"];
   boot.initrd.kernelModules = ["loop" "overlay"];


### PR DESCRIPTION
I think that the "no bootloader" setting should come with the module.