### PR TITLE
ssvnode mainnet

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1703939110,
-        "narHash": "sha256-GgjYWkkHQ8pUBwXX++ah+4d07DqOeCDaaQL6Ab86C50=",
+        "lastModified": 1707653290,
+        "narHash": "sha256-BZoeaofvEPuf2pw+k6VoRDiE/E5/3w7z0jrKfQCiXco=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "7354096fc026f79645fdac73e9aeea71a09412c3",
+        "rev": "91a572c9866b92294aec152b65fa06c4dad7816f",
         "type": "github"
       },
       "original": {
@@ -39,18 +39,21 @@
     },
     "devshell": {
       "inputs": {
+        "flake-utils": [
+          "ethereum-nix",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "ethereum-nix",
           "nixpkgs"
-        ],
-        "systems": "systems_2"
+        ]
       },
       "locked": {
-        "lastModified": 1701787589,
-        "narHash": "sha256-ce+oQR4Zq9VOsLoh9bZT8Ip9PaMLcjjBUHVPzW5d7Cw=",
+        "lastModified": 1705332421,
+        "narHash": "sha256-USpGLPme1IuqG78JNqSaRabilwkCyHmVWY0M9vYyqEA=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "44ddedcbcfc2d52a76b64fb6122f209881bd3e1e",
+        "rev": "83cb93d6d063ad290beee669f4badf9914cc16ec",
         "type": "github"
       },
       "original": {
@@ -66,20 +69,22 @@
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts",
         "flake-root": "flake-root",
+        "flake-utils": "flake-utils_2",
         "foundry-nix": "foundry-nix",
         "lib-extras": "lib-extras",
         "mynixpkgs": "mynixpkgs",
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "poetry2nix": "poetry2nix",
-        "treefmt-nix": "treefmt-nix_2"
+        "systems": "systems_2",
+        "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1704710576,
-        "narHash": "sha256-kx9pEwUol+OFoIOcgUi5/ELKs4V0KS/P+weCJyg4HGw=",
+        "lastModified": 1707752919,
+        "narHash": "sha256-gzmqJMkl2lisSj349L1MbhS/3UR3r6LTF0f7nrE2Wrw=",
         "owner": "nix-community",
         "repo": "ethereum.nix",
-        "rev": "171ec270c4321b273a72ea4e77e94181083498ba",
+        "rev": "bcc6b02fee78fad5280a84061719d25e7303bf7a",
         "type": "github"
       },
       "original": {
@@ -127,11 +132,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1704152458,
-        "narHash": "sha256-DS+dGw7SKygIWf9w4eNBUZsK+4Ug27NwEWmn2tnbycg=",
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "88a2cd8166694ba0b6cb374700799cec53aef527",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
         "type": "github"
       },
       "original": {
@@ -145,11 +150,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1704152458,
-        "narHash": "sha256-DS+dGw7SKygIWf9w4eNBUZsK+4Ug27NwEWmn2tnbycg=",
+        "lastModified": 1706830856,
+        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "88a2cd8166694ba0b6cb374700799cec53aef527",
+        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
         "type": "github"
       },
       "original": {
@@ -192,30 +197,18 @@
       }
     },
     "flake-utils_2": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_3": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": [
+          "ethereum-nix",
+          "systems"
+        ]
       },
       "locked": {
-        "lastModified": 1694529238,
-        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -226,18 +219,21 @@
     },
     "foundry-nix": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": [
+          "ethereum-nix",
+          "flake-utils"
+        ],
         "nixpkgs": [
           "ethereum-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1704618633,
-        "narHash": "sha256-Eh+ODxCy7mj/ARa5rXzfL5aGo84GSf+jcPeZdALLs+g=",
+        "lastModified": 1707037862,
+        "narHash": "sha256-jCNrmFDx+neh7Uz0Q2kmqz19Yyz8OxnGoZpzd2w3SME=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "6dc7e069a10ccd3c83589c81a7b01b9373474bf9",
+        "rev": "03b8af1efb00c51dceaac92462dc77b1b57683e0",
         "type": "github"
       },
       "original": {
@@ -379,11 +375,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702230402,
-        "narHash": "sha256-PwhdihM7lOp9l8jxqiNHDT29h0saSgedw6TYs1Y+bkQ=",
+        "lastModified": 1706558129,
+        "narHash": "sha256-ZKGarjd5pNhY2GgLO9e8ia9PYoPCmtvw3EH5tVbcIaA=",
         "owner": "aldoborrero",
         "repo": "mynixpkgs",
-        "rev": "67a7db27330f85af19f3ce52ae06671e573968ea",
+        "rev": "e314504ac0eb2b27f7813c63d00a9050c2e31784",
         "type": "github"
       },
       "original": {
@@ -457,11 +453,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1703961334,
-        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "lastModified": 1706550542,
+        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
         "type": "github"
       },
       "original": {
@@ -522,11 +518,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1704161960,
-        "narHash": "sha256-QGua89Pmq+FBAro8NriTuoO/wNaUtugt29/qqA8zeeM=",
+        "lastModified": 1707588924,
+        "narHash": "sha256-0e1ce6X5ghapv6cAF9rxLZKeNyFHHXsLbGxN2cQQE8U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "63143ac2c9186be6d9da6035fa22620018c85932",
+        "rev": "10b813040df67c4039086db0f6eaf65c536886c6",
         "type": "github"
       },
       "original": {
@@ -538,27 +534,27 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1685566663,
-        "narHash": "sha256-btHN1czJ6rzteeCuE/PNrdssqYD2nIA4w48miQAFloM=",
+        "lastModified": 1701282334,
+        "narHash": "sha256-MxCVrXY6v4QmfTwIysjjaX0XUhqBbxTWWB4HXtDYsdk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4ecab3273592f27479a583fb6d975d4aba3486fe",
+        "rev": "057f9aecfb71c4437d2b27d3323df7f93c010b7e",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "23.05",
+        "ref": "23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1704538339,
-        "narHash": "sha256-1734d3mQuux9ySvwf6axRWZRBhtcZA9Q8eftD6EZg6U=",
+        "lastModified": 1707546158,
+        "narHash": "sha256-nYYJTpzfPMDxI8mzhQsYjIUX+grorqjKEU9Np6Xwy/0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46ae0210ce163b3cba6c7da08840c1d63de9c701",
+        "rev": "d934204a0f8d9198e1e4515dd6fec76a139c87f0",
         "type": "github"
       },
       "original": {
@@ -570,21 +566,30 @@
     },
     "poetry2nix": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
+        "flake-utils": [
+          "ethereum-nix",
+          "flake-utils"
+        ],
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": [
           "ethereum-nix",
           "nixpkgs"
         ],
-        "systems": "systems_4",
-        "treefmt-nix": "treefmt-nix"
+        "systems": [
+          "ethereum-nix",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "ethereum-nix",
+          "treefmt-nix"
+        ]
       },
       "locked": {
-        "lastModified": 1704540236,
-        "narHash": "sha256-VKQ7JUjINd34sYhH7DKTtqnARvRySJ808cW9hoYA8NQ=",
+        "lastModified": 1707195113,
+        "narHash": "sha256-xPFxTMe4rKE/ZWLlOWv22qpGwpozpR+U1zhyf1040Zk=",
         "owner": "nix-community",
         "repo": "poetry2nix",
-        "rev": "74921da7e0cc8918adc2e9989bd3e9c127b25ff6",
+        "rev": "4eb2ac54029af42a001c9901194e9ce19cbd8a40",
         "type": "github"
       },
       "original": {
@@ -608,11 +613,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1688056373,
-        "narHash": "sha256-2+SDlNRTKsgo3LBRiMUcoEUb6sDViRNQhzJquZ4koOI=",
+        "lastModified": 1704725188,
+        "narHash": "sha256-qq8NbkhRZF1vVYQFt1s8Mbgo8knj+83+QlL5LBnYGpI=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "5843cf069272d92b60c3ed9e55b7a8989c01d4c7",
+        "rev": "ea96f0c05924341c551a797aaba8126334c505d2",
         "type": "github"
       },
       "original": {
@@ -660,70 +665,19 @@
         "type": "github"
       }
     },
-    "systems_3": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_4": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "id": "systems",
-        "type": "indirect"
-      }
-    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
           "ethereum-nix",
-          "poetry2nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1699786194,
-        "narHash": "sha256-3h3EH1FXQkIeAuzaWB+nK0XK54uSD46pp+dMD3gAcB4=",
+        "lastModified": 1707300477,
+        "narHash": "sha256-qQF0fEkHlnxHcrKIMRzOETnRBksUK048MXkX0SOmxvA=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "e82f32aa7f06bbbd56d7b12186d555223dc399d1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "ethereum-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1704233915,
-        "narHash": "sha256-GYDC4HjyVizxnyKRbkrh1GugGp8PP3+fJuh40RPCN7k=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "e434da615ef74187ba003b529cc72f425f5d941e",
+        "rev": "ac599dab59a66304eb511af07b3883114f061b9d",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,19 @@
           config = {};
         };
         overlayAttrs = {
-          inherit (config.packages) buidl nethermind nimbus prysm reth ssvnode teku homestakeros;
+          inherit
+            (config.packages)
+            erigon
+            lighthouse
+            nethermind
+            nimbus
+            prysm
+            reth
+            ssvnode
+            teku
+            buidl
+            homestakeros
+            ;
         };
 
         # Nix code formatter, accessible through 'nix fmt'
@@ -85,6 +97,8 @@
           rec {
             "buidl" = pkgs.callPackage ./packages/buidl {};
             # Ethereum.nix
+            "erigon" = inputs.ethereum-nix.packages.${system}.erigon;
+            "lighthouse" = inputs.ethereum-nix.packages.${system}.lighthouse;
             "nethermind" = inputs.ethereum-nix.packages.${system}.nethermind;
             "nimbus" = inputs.ethereum-nix.packages.${system}.nimbus;
             "prysm" = inputs.ethereum-nix.packages.${system}.prysm;

--- a/modules/homestakeros/default.nix
+++ b/modules/homestakeros/default.nix
@@ -234,7 +234,7 @@ in {
                   BuilderProposals: true
 
               eth2:
-                BeaconNodeAddr: ws://${parsedConsensusEndpoint.addr}:${parsedConsensusEndpoint.port}:
+                BeaconNodeAddr: ws://${parsedConsensusEndpoint.addr}:${parsedConsensusEndpoint.port}
                 Network: mainnet
 
               eth1:

--- a/modules/homestakeros/default.nix
+++ b/modules/homestakeros/default.nix
@@ -240,7 +240,7 @@ in {
               eth1:
                 # This assumes that the websocket is bind to the same port, true for erigon, not for others
                 # TODO: Consider having a variable name for websocket endpoint
-                ETH1Addr: ws://${parsedExecutionEndpoint.addr}:${parsedExecutionEndpoint.port}
+                ETH1Addr: ws://${parsedExecutionEndpoint.addr}:8545
 
               KeyStore:
                 PrivateKeyFile: ${cfg.addons.ssv-node.privateKeyFile}

--- a/modules/homestakeros/default.nix
+++ b/modules/homestakeros/default.nix
@@ -240,7 +240,7 @@ in {
               eth1:
                 # This assumes that the websocket is bind to the same port, true for erigon, not for others
                 # TODO: Consider having a variable name for websocket endpoint
-                ETH1Addr: ws://${parsedExecutionEndpoint.addr}:8545
+                ETH1Addr: ws://${parsedExecutionEndpoint.addr}:8546
 
               KeyStore:
                 PrivateKeyFile: ${cfg.addons.ssv-node.privateKeyFile}

--- a/modules/homestakeros/default.nix
+++ b/modules/homestakeros/default.nix
@@ -257,6 +257,11 @@ in {
               ${pkgs.ssvnode}/bin/ssvnode start-node --config ${ssvConfig}
             '';
             wantedBy = ["multi-user.target"];
+            serviceConfig = {
+              Restart = "always";
+              RestartSec = "5s";
+              Type = "simple";
+            };
           };
           systemd.timers.ssv-autostart = {
             timerConfig.OnBootSec = "10min";

--- a/modules/homestakeros/default.nix
+++ b/modules/homestakeros/default.nix
@@ -207,6 +207,8 @@ in {
         (
           cfg.addons.ssv-node.privateKeyFile
           != null
+          && cfg.addons.ssv-node.privateKeyPasswordFile
+          != null
           && pkgs.system == "x86_64-linux"
           && length activeConsensusClients > 0
           && length activeExecutionClients > 0
@@ -237,13 +239,19 @@ in {
 
               eth1:
                 ETH1Addr: ${cfg.execution.${executionClient}.endpoint}
+
+              KeyStore:
+                PrivateKeyFile: ${cfg.addons.ssv-node.privateKeyFile}
+                PasswordFile: ${cfg.addons.ssv-node.privateKeyPasswordFile}
             '';
           in {
             description = "Start the SSV node if the private operator key exists";
-            unitConfig.ConditionPathExists = ["${cfg.addons.ssv-node.privateKeyFile}"];
+            unitConfig.ConditionPathExists = [
+              "${cfg.addons.ssv-node.privateKeyFile}"
+              "${cfg.addons.ssv-node.privateKeyPasswordFile}"
+            ];
             # The operator key is defined here, so it does not need to be evaluated
             script = ''
-              export OPERATOR_KEY=$(cat ${cfg.addons.ssv-node.privateKeyFile})
               ${pkgs.ssvnode}/bin/ssvnode start-node --config ${ssvConfig}
             '';
             wantedBy = ["multi-user.target"];

--- a/modules/homestakeros/default.nix
+++ b/modules/homestakeros/default.nix
@@ -218,7 +218,7 @@ in {
             # TODO: This is a bad way to do this, prevents multiple instances
             executionClient = builtins.elemAt activeExecutionClients 0;
             consensusClient = builtins.elemAt activeConsensusClients 0;
-            parsedConsensusEndpoint = parseEndpoint cfg.consensus.${consensusClient}.endpoint;
+            parsedExecutionEndpoint = parseEndpoint cfg.execution.${executionClient}.endpoint;
 
             ssvConfig = pkgs.writeText "config.yaml" ''
               global:
@@ -234,11 +234,13 @@ in {
                   BuilderProposals: true
 
               eth2:
-                BeaconNodeAddr: ws://${parsedConsensusEndpoint.addr}:${parsedConsensusEndpoint.port}
+                BeaconNodeAddr: ${cfg.consensus.${consensusClient}.endpoint}
                 Network: mainnet
 
               eth1:
-                ETH1Addr: ${cfg.execution.${executionClient}.endpoint}
+                # This assumes that the websocket is bind to the same port, true for erigon, not for others
+                # TODO: Consider having a variable name for websocket endpoint
+                ETH1Addr: ws://${parsedExecutionEndpoint.addr}:${parsedExecutionEndpoint.port}
 
               KeyStore:
                 PrivateKeyFile: ${cfg.addons.ssv-node.privateKeyFile}

--- a/modules/homestakeros/options.nix
+++ b/modules/homestakeros/options.nix
@@ -315,6 +315,11 @@
           default = "/var/mnt/addons/ssv/ssv_operator_key";
           description = "Path to the private SSV operator key.";
         };
+        privateKeyPasswordFile = mkOption {
+          type = types.nullOr types.path;
+          default = "/var/mnt/addons/ssv/password";
+          description = "Path to the password file of SSV operator key";
+        };
         dataDir = mkOption {
           type = types.path;
           default = "/var/mnt/addons/ssv";


### PR DESCRIPTION
ponkila-ephemeral-beta is now running ssvnode on mainnet, which required:

- erigon and lighthouse to updated (erigon got stuck with torrent downloading)
- new privatekey password option has been added to ssvnode, which is reflected here
- the ssvnode config was wrong, which is now fixed
- i added serviceConfig to restart the process automatically -- this is because if ssvnode reads that the CL client is optimistic (i.e., it falls behind) the software kills itself. this is unwanted reaction, because sometimes nodes might fall behind for a few seconds when chains get reorganized or there is some other propagation error in the network