### PR TITLE
lighthouse: add quic port to allowedPorts

### DIFF
--- a/modules/homestakeros/default.nix
+++ b/modules/homestakeros/default.nix
@@ -504,7 +504,7 @@ in {
             )
             "--metrics"
           ];
-          allowedPorts = [9000];
+          allowedPorts = [9000 9001];
         in (createService serviceName serviceType execStart parsedEndpoint allowedPorts)
       )
 


### PR DESCRIPTION
lighthouse now serves QUIC listener on UDP port 9001, so adding it here. One mishap: the current configuration does not allow ports to be defined port TCP and per UDP, but maybe this can be WIP.